### PR TITLE
update insertEdge query

### DIFF
--- a/pkg/dbconnector/insertEdge.go
+++ b/pkg/dbconnector/insertEdge.go
@@ -76,7 +76,9 @@ func ChunkedInsertEdge(resources []Edge) ChunkedOperationResult {
 // e.g. MATCH (s:{_uid:'abc'}), (d) WHERE d._uid='def' OR d._uid='ghi' CREATE (s)-[:Type]>(d)
 func insertEdge(edge Edge, whereClause string) (QueryResult, error) {
 	query := fmt.Sprintf("MATCH (s {_uid: '%s'}), (d) %s CREATE (s)-[:%s]->(d)", edge.SourceUID, whereClause, edge.EdgeType)
-	if edge.SourceKind != "" && edge.DestKind != "" {
+	//Insert with node labels if only one edge is inserted at a time.
+	//If there are multiple edges being inserted, the edge destkinds might be different
+	if edge.SourceKind != "" && edge.DestKind != "" && whereClause == "" {
 		query = fmt.Sprintf("MATCH (s:%s {_uid: '%s'}), (d:%s) %s CREATE (s)-[:%s]->(d)", edge.SourceKind, edge.SourceUID, edge.DestKind, whereClause, edge.EdgeType)
 	}
 	//glog.Info(query)


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/2200

This resulted in edge counts not matching resulting in resyncs. If there are multiple edges being inserted at the same time, the edge destkinds might be different.