### PR TITLE
[release-1.0.0] Add go.mod to work around downstream Cachito limitations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+// DO NOT DELETE THIS FILE WITHOUT CONSULTING @arewm This is needed for downstream!
+module github.com/open-cluster-management/search-aggregator
+
+go 1.11


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/2292#issuecomment-630915716

Downstream Cachito only supports go.mod, since this project is using dep, we need to add a no-op go.mod to satisfy Cachito.

Merging into release-1.0.0 branch only to be included in 1.0.1.  We started a full migration to go mod, and that's been partially merged to master and release-2.0

