### PR TITLE
Call db.IsPropertySet only if err is nil

### DIFF
--- a/pkg/dbconnector/redisinterfacev2.go
+++ b/pkg/dbconnector/redisinterfacev2.go
@@ -33,9 +33,6 @@ type RedisGraphStoreV2 struct{}
 // Called by the other functions in this file
 // Not fully implemented
 func (RedisGraphStoreV2) Query(q string) (*rg2.QueryResult, error) {
-	//Initialize return vars
-	var result *rg2.QueryResult
-	var err error
 	// Get connection from the pool
 	conn := Pool.Get() // This will block if there aren't any valid connections that are available.
 	defer conn.Close()
@@ -43,7 +40,7 @@ func (RedisGraphStoreV2) Query(q string) (*rg2.QueryResult, error) {
 		Conn: conn,
 		Id:   GRAPH_NAME,
 	}
-	result, err = g.Query(q)
+	result, err := g.Query(q)
 	if err != nil {
 		glog.Error("Error fetching results from RedisGraph V2 : ", err)
 	}


### PR DESCRIPTION
Avoid aggregator panic when Redisgraph is not available. Saw it happening on cluster mentioned in https://github.com/open-cluster-management/backlog/issues/3419