### PR TITLE
[release-2.0] Call db.IsPropertySet only if err is nil

### DIFF
--- a/pkg/clustermgmt/clusterWatch.go
+++ b/pkg/clustermgmt/clusterWatch.go
@@ -151,7 +151,7 @@ func processClusterUpsert(obj interface{}, kubeClient *kubeClientset.Clientset) 
 		return
 	}
 
-	if db.IsGraphMissing(err) || !db.IsPropertySet(res) {
+	if db.IsGraphMissing(err) || (err == nil && !db.IsPropertySet(res)) {
 		glog.Infof("Node for cluster %s does not exist, inserting it.", resource.Properties["name"])
 		_, _, err = db.Insert([]*db.Resource{&resource}, "")
 		if err != nil {


### PR DESCRIPTION
Avoid aggregator panic when Redisgraph is not available. Saw it happening on cluster mentioned in open-cluster-management/backlog#3419