### PR TITLE
Update to UBI 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/6835

Fixes image vulnerabilities.
![image](https://user-images.githubusercontent.com/4671325/98855708-6d8b3c80-242a-11eb-97b2-7b0ec0467d3d.png)
