### PR TITLE
Increase DEFAULT_REQUEST_LIMIT to 10

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ const (
 	DEFAULT_REDIS_HOST              = "localhost"
 	DEFAULT_REDIS_PORT              = "6379"
 	DEFAULT_REDIS_WATCH_INTERVAL    = 15000 // 15 seconds
-	DEFAULT_REQUEST_LIMIT           = 5     // Max number of concurrent requests.
+	DEFAULT_REQUEST_LIMIT           = 10    // Max number of concurrent requests.
 	DEFAULT_SKIP_CLUSTER_VALIDATION = "false"
 )
 


### PR DESCRIPTION
From observing various environments, the current default request limit is too conservative.  I'm increasing it gradually until we gather more data about its optimal setting.