### PR TITLE
revert copyright updates

### DIFF
--- a/build/Configfile
+++ b/build/Configfile
@@ -1,6 +1,4 @@
- # Copyright Contributors to the Open Cluster Management project
- 
- # Only use git commands if it exists
+# Only use git commands if it exists
 ifdef GIT
 VCS_URL ?=$(shell git config --get remote.origin.url)
 IMAGE_VERSION :=$(shell git rev-parse --short HEAD)

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
- # Copyright Contributors to the Open Cluster Management project
- 
+
 echo " > Running build.sh"
 set -e
 

--- a/build/copyright-check.sh
+++ b/build/copyright-check.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 ###############################################################################
 # (c) Copyright IBM Corporation 2019, 2020. All Rights Reserved.
+# Note to U.S. Government Users Restricted Rights:
+# U.S. Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule
+# Contract with IBM Corp.
+# Licensed Materials - Property of IBM
 # Copyright (c) 2020 Red Hat, Inc.
-# Copyright Contributors to the Open Cluster Management project
 ###############################################################################
 
 #Project start year

--- a/build/deploy-to-cluster.sh
+++ b/build/deploy-to-cluster.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Copyright Contributors to the Open Cluster Management project
 
 echo " > Running deploy-to-cluster.sh"
 set -e

--- a/build/install-dependencies.sh
+++ b/build/install-dependencies.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
- # Copyright Contributors to the Open Cluster Management project
- 
+
 echo " > Running install-dependencies.sh"
 set -e
 make deps

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
- # Copyright Contributors to the Open Cluster Management project
- 
+
 echo " > Running run-e2e-test.sh"
 exit 0

--- a/build/run-unit-tests.sh
+++ b/build/run-unit-tests.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
- # Copyright Contributors to the Open Cluster Management project
- 
+
 echo " > Running run-unit-tests.sh"
 set -e
 export DOCKER_IMAGE_AND_TAG=${1}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
+*/
+// Copyright (c) 2020 Red Hat, Inc.
+
 package main
 
 import (

--- a/pkg/clustermgmt/clusterWatch.go
+++ b/pkg/clustermgmt/clusterWatch.go
@@ -1,7 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
 */
 
 package clustermgmt

--- a/pkg/clustermgmt/clusterWatch_test.go
+++ b/pkg/clustermgmt/clusterWatch_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
+
 package clustermgmt
 
 import (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
 */
 
 package config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
+
 package config
 
 import (

--- a/pkg/config/kubeClient.go
+++ b/pkg/config/kubeClient.go
@@ -1,7 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
 */
 
 package config

--- a/pkg/config/kubeClient_test.go
+++ b/pkg/config/kubeClient_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
+
 package config
 
 import (

--- a/pkg/dbconnector/delete.go
+++ b/pkg/dbconnector/delete.go
@@ -1,8 +1,12 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
+// Copyright (c) 2020 Red Hat, Inc.
+
 package dbconnector
 
 import (

--- a/pkg/dbconnector/deleteEdge.go
+++ b/pkg/dbconnector/deleteEdge.go
@@ -1,8 +1,12 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
+// Copyright (c) 2020 Red Hat, Inc.
+
 package dbconnector
 
 import (

--- a/pkg/dbconnector/deleteEdge_test.go
+++ b/pkg/dbconnector/deleteEdge_test.go
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
 package dbconnector
 
 import (

--- a/pkg/dbconnector/encode.go
+++ b/pkg/dbconnector/encode.go
@@ -1,7 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
 */
 
 package dbconnector

--- a/pkg/dbconnector/encode_test.go
+++ b/pkg/dbconnector/encode_test.go
@@ -1,7 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
 */
 package dbconnector
 

--- a/pkg/dbconnector/graphOperations.go
+++ b/pkg/dbconnector/graphOperations.go
@@ -1,8 +1,12 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
+// Copyright (c) 2020 Red Hat, Inc.
+
 package dbconnector
 
 import (

--- a/pkg/dbconnector/graphOperations_test.go
+++ b/pkg/dbconnector/graphOperations_test.go
@@ -1,6 +1,8 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
 */
 package dbconnector
 

--- a/pkg/dbconnector/helpers.go
+++ b/pkg/dbconnector/helpers.go
@@ -1,7 +1,9 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
+*/
 
 package dbconnector
 

--- a/pkg/dbconnector/insert.go
+++ b/pkg/dbconnector/insert.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package dbconnector
 

--- a/pkg/dbconnector/insertEdge.go
+++ b/pkg/dbconnector/insertEdge.go
@@ -1,7 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
 */
 
 package dbconnector

--- a/pkg/dbconnector/insertEdge_test.go
+++ b/pkg/dbconnector/insertEdge_test.go
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
 package dbconnector
 
 import (

--- a/pkg/dbconnector/insertIndex.go
+++ b/pkg/dbconnector/insertIndex.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+//# Copyright (c) 2020 Red Hat, Inc
+
 package dbconnector
 
 import (

--- a/pkg/dbconnector/pool.go
+++ b/pkg/dbconnector/pool.go
@@ -1,7 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
 */
 
 package dbconnector

--- a/pkg/dbconnector/rbacHelper.go
+++ b/pkg/dbconnector/rbacHelper.go
@@ -1,6 +1,8 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
 */
 
 package dbconnector

--- a/pkg/dbconnector/redisinterfacev2.go
+++ b/pkg/dbconnector/redisinterfacev2.go
@@ -1,7 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
 */
 
 package dbconnector

--- a/pkg/dbconnector/redislivliness.go
+++ b/pkg/dbconnector/redislivliness.go
@@ -1,8 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
+*/
+// Copyright (c) 2020 Red Hat, Inc.
+
 package dbconnector
 
 import (

--- a/pkg/dbconnector/sanitizeQuery.go
+++ b/pkg/dbconnector/sanitizeQuery.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
+
 package dbconnector
 
 import (

--- a/pkg/dbconnector/update.go
+++ b/pkg/dbconnector/update.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package dbconnector
 

--- a/pkg/handlers/healthProbes.go
+++ b/pkg/handlers/healthProbes.go
@@ -1,7 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
 */
 
 package handlers

--- a/pkg/handlers/healthProbes_test.go
+++ b/pkg/handlers/healthProbes_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
+
 package handlers
 
 import (

--- a/pkg/handlers/helpers.go
+++ b/pkg/handlers/helpers.go
@@ -1,7 +1,9 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
+Copyright (c) 2020 Red Hat, Inc.
 */
 package handlers
 

--- a/pkg/handlers/helpers_test.go
+++ b/pkg/handlers/helpers_test.go
@@ -1,6 +1,8 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets, irrespective of what has been deposited with the U.S. Copyright Office.
 */
 package handlers
 

--- a/pkg/handlers/interClusterEdges.go
+++ b/pkg/handlers/interClusterEdges.go
@@ -1,8 +1,12 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
+// Copyright (c) 2020 Red Hat, Inc.
+
 package handlers
 
 import (

--- a/pkg/handlers/metrics.go
+++ b/pkg/handlers/metrics.go
@@ -1,7 +1,11 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
 */
 package handlers
 

--- a/pkg/handlers/metrics_test.go
+++ b/pkg/handlers/metrics_test.go
@@ -1,8 +1,10 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright Contributors to the Open Cluster Management project
- */
-
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2020 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+*/
 package handlers
 
 import (

--- a/pkg/handlers/resyncCluster.go
+++ b/pkg/handlers/resyncCluster.go
@@ -1,8 +1,12 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package handlers
 

--- a/pkg/handlers/resyncCluster_test.go
+++ b/pkg/handlers/resyncCluster_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+// Copyright (c) 2020 Red Hat, Inc.
+
 package handlers
 
 import (

--- a/pkg/handlers/syncResources.go
+++ b/pkg/handlers/syncResources.go
@@ -1,8 +1,12 @@
 /*
- * (C) Copyright IBM Corporation 2019 All Rights Reserved
- * Copyright (c) 2020 Red Hat, Inc.
- * Copyright Contributors to the Open Cluster Management project
- */
+IBM Confidential
+OCO Source Materials
+(C) Copyright IBM Corporation 2019 All Rights Reserved
+The source code for this program is not published or otherwise divested of its trade secrets,
+irrespective of what has been deposited with the U.S. Copyright Office.
+
+Copyright (c) 2020 Red Hat, Inc.
+*/
 
 package handlers
 


### PR DESCRIPTION
This reverts parts of commit b81a788.

**Description of changes:**

The guidance is to keep the existing copyright language and add the new copyrights below.
