### PR TITLE
Reject concurrent requests from same cluster

### DIFF
--- a/pkg/handlers/syncResources.go
+++ b/pkg/handlers/syncResources.go
@@ -82,6 +82,11 @@ func SyncResources(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Aggregator has many pending requests, retry later.", http.StatusTooManyRequests)
 		return
 	}
+	if _, exist := PendingRequests[clusterName]; exist == true {
+		glog.Warningf("Rejecting request from %s because a previous request from this cluster is still processing.", clusterName)
+		http.Error(w, "A previous request from this cluster is still processing, retry later.", http.StatusTooManyRequests)
+		return
+	}
 
 	glog.V(2).Info("Starting SyncResources() for cluster: ", clusterName)
 	metrics := InitSyncMetrics(clusterName)
@@ -90,6 +95,10 @@ func SyncResources(w http.ResponseWriter, r *http.Request) {
 	subscriptionUpdated := false                // flag to decide the time when last suscription was changed
 	subscriptionUIDMap := make(map[string]bool) // map to hold exisiting subscription uids
 	response := SyncResponse{Version: config.AGGREGATOR_API_VERSION}
+
+	// !!! DO NOT APPROVE OR MERGE WITH THIS !!!
+	// Adding delay to test.
+	time.Sleep(6 * time.Minute)
 
 	// Function that sends the current response and the given status code.
 	// If you want to bail out early, make sure to call return right after.

--- a/pkg/handlers/syncResources.go
+++ b/pkg/handlers/syncResources.go
@@ -77,14 +77,14 @@ func SyncResources(w http.ResponseWriter, r *http.Request) {
 	// TODO: The next step is to degrade performance instead of rejecting the request.
 	//       We will give priority to nodes over edges after reaching certain load.
 	//       Will also prioritize small updates over a large resync.
-	if len(PendingRequests) >= config.Cfg.RequestLimit && clusterName != "local-cluster" {
-		glog.Warningf("Too many pending requests (%d). Rejecting sync from %s", len(PendingRequests), clusterName)
-		http.Error(w, "Aggregator has many pending requests, retry later.", http.StatusTooManyRequests)
-		return
-	}
 	if _, exist := PendingRequests[clusterName]; exist {
 		glog.Warningf("Rejecting request from %s. A previous request from this cluster is processing.", clusterName)
 		http.Error(w, "A previous request from this cluster is processing, retry later.", http.StatusTooManyRequests)
+		return
+	}
+	if len(PendingRequests) >= config.Cfg.RequestLimit && clusterName != "local-cluster" {
+		glog.Warningf("Too many pending requests (%d). Rejecting sync from %s", len(PendingRequests), clusterName)
+		http.Error(w, "Aggregator has many pending requests, retry later.", http.StatusTooManyRequests)
 		return
 	}
 

--- a/pkg/handlers/syncResources.go
+++ b/pkg/handlers/syncResources.go
@@ -83,8 +83,8 @@ func SyncResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if _, exist := PendingRequests[clusterName]; exist == true {
-		glog.Warningf("Rejecting request from %s because a previous request from this cluster is still processing.", clusterName)
-		http.Error(w, "A previous request from this cluster is still processing, retry later.", http.StatusTooManyRequests)
+		glog.Warningf("Rejecting request from %s. A previous request from this cluster is processing.", clusterName)
+		http.Error(w, "A previous request from this cluster is processing, retry later.", http.StatusTooManyRequests)
 		return
 	}
 

--- a/pkg/handlers/syncResources.go
+++ b/pkg/handlers/syncResources.go
@@ -82,7 +82,7 @@ func SyncResources(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Aggregator has many pending requests, retry later.", http.StatusTooManyRequests)
 		return
 	}
-	if _, exist := PendingRequests[clusterName]; exist == true {
+	if _, exist := PendingRequests[clusterName]; exist {
 		glog.Warningf("Rejecting request from %s. A previous request from this cluster is processing.", clusterName)
 		http.Error(w, "A previous request from this cluster is processing, retry later.", http.StatusTooManyRequests)
 		return
@@ -95,10 +95,6 @@ func SyncResources(w http.ResponseWriter, r *http.Request) {
 	subscriptionUpdated := false                // flag to decide the time when last suscription was changed
 	subscriptionUIDMap := make(map[string]bool) // map to hold exisiting subscription uids
 	response := SyncResponse{Version: config.AGGREGATOR_API_VERSION}
-
-	// !!! DO NOT APPROVE OR MERGE WITH THIS !!!
-	// Adding delay to test.
-	time.Sleep(6 * time.Minute)
 
 	// Function that sends the current response and the given status code.
 	// If you want to bail out early, make sure to call return right after.


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/22937
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2092863

### Description of changes
- Reject sync request if there's a pending request for the same cluster. This situation can happen if the request times out elsewhere in the network.

_Note: Our V2 indexer should handle this scenario better because we are using the request `context`, which should trigger if the request times out._


