### PR TITLE
Revert hive library to fix downstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace k8s.io/client-go => k8s.io/client-go v0.24.3
+replace (
+	k8s.io/client-go => k8s.io/client-go v0.24.3
+	github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20220121012553-a0671aa97ef3
+)


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/26637

### Description of changes
- Revert hive version replace because it breaks downstream because oof cachito dependency.
