### PR TITLE
ACM-5513: Update go to v1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
 
 WORKDIR /go/src/github.com/stolostron/search-aggregator
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-linux:
 .PHONY: lint
 lint:
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.47.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.52.2
 	CGO_ENABLED=0 GOGC=25 golangci-lint run --timeout=3m
 	
 run:

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -5,7 +5,7 @@
 .PHONY: lint
 lint:
 	GOPATH=$(go env GOPATH)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.47.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.52.2
 	CGO_ENABLED=0 GOGC=25 golangci-lint run --timeout=3m
 	
 .PHONY: unit-test

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 // Copyright Contributors to the Open Cluster Management project
 module github.com/stolostron/search-aggregator
 
-go 1.18
+go 1.20
 
 require (
 	github.com/golang/glog v1.0.0
@@ -71,6 +71,6 @@ require (
 )
 
 replace (
-	k8s.io/client-go => k8s.io/client-go v0.24.3
 	github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20220121012553-a0671aa97ef3
+	k8s.io/client-go => k8s.io/client-go v0.24.3
 )


### PR DESCRIPTION
**Related Issue:**  ACM-5513

### Description of changes
- Update go version to 1.20

/cherry-pick release-2.6
